### PR TITLE
Add Marginalia and Aside components for editorial sidenotes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -38,7 +38,15 @@
       "Bash(gh search:*)",
       "Bash(tr '}' '\\\\n')",
       "Bash(npm uninstall:*)",
-      "Bash(npm view:*)"
+      "Bash(npm view:*)",
+      "WebFetch(domain:api.anthropic.com)",
+      "Bash(mkdir -p /tmp/anthropic-design)",
+      "Read(//tmp/**)",
+      "Bash(cp /Users/mcclowes/.claude/projects/-Users-mcclowes-Development-mcclowes-mcclowes-com/27a883ab-0c6a-421e-bf67-95c0f2402996/tool-results/webfetch-1776464975315-etow3m.bin ./design.gz)",
+      "Read(//private/tmp/anthropic-design/**)",
+      "Bash(gunzip -k design.gz)",
+      "Bash(mkdir -p extracted)",
+      "Bash(tar -xf design -C extracted)"
     ],
     "deny": [],
     "ask": []

--- a/blog/2026-04-18-marginalia-demo.mdx
+++ b/blog/2026-04-18-marginalia-demo.mdx
@@ -1,0 +1,38 @@
+---
+title: 'A reader in two columns'
+authors: mcclowes
+tags: [design, typography, web]
+draft: true
+---
+
+import { Marginalia, Aside, Endpoint } from '@site/src/components/Marginalia';
+
+A small experiment in editorial layout: margin notes that know where they belong.
+
+<!--truncate-->
+
+<Marginalia>
+
+## The classical margin
+
+A reader moves through the main column at their own pace, and the author — quietly, in a second register — can gloss, caveat, link, or point. Edward Tufte made a career of it; medieval scribes made an art of it. The web, generally, threw it away.
+
+There are reasons for that. Margins on the web are fragile: they compete with sidebars, they evaporate at mobile widths, and they force a layout discipline most CMSs don't encourage. But the idea is worth reviving, because there is real content that doesn't belong in the main flow — <Aside anchor="pattern language" kind="concept" title="Christopher Alexander" meta={["1977", "253 patterns"]} cta="Read on archive.org →">*A Pattern Language* (1977) catalogued 253 patterns for towns and buildings, from "Mosaic of Subcultures" to "Six-Foot Balcony". It's also the root of much software-architecture thinking.</Aside> footnotes, digressions, references — and shoving all of it into a separate "Notes" section at the end is a concession, not a solution.
+
+## How it works
+
+Inline anchors in the prose, with dashed underlines, each paired with a card floating in the right margin. Scroll past an anchor and its card lights up. Hover the card and the anchor lights up. Click either and they pulse in agreement. It is, at minimum, a more honest rendering of how reading actually <Aside anchor="works" kind="warning" title="One caveat" meta={["viewport < 1200px"]}>The margin collapses on viewports under 1200px. On phones, readers only see the anchor underline, not the card body. Accept the tradeoff or build a mobile popover — don't pretend it's the same experience.</Aside> — nonlinear, parenthetical, cross-referenced.
+
+## The implementation
+
+A React context, a little geometry. Each `<Aside>` registers itself with a `<Marginalia>` container, handing over a ref to its inline anchor. The container measures, packs the cards top-to-bottom without overlap, and listens for scroll to pick out the "hot" reference — the one closest to the reader's eye line, roughly a third of the way down the viewport.
+
+It also supports inline API chips for doc-flavored posts: <Endpoint method="POST" path="/login" />, <Endpoint method="GET" path="/users/{id}" />, or <Endpoint method="DELETE" path="/session" />. Wrap one in an `<Aside>` to pair it with a <Aside anchor="rich reference card" kind="endpoint" title="Login endpoint" meta={["POST", "Auth", "200 / 400 / 401"]} cta="Open in API reference →">Authenticates a user with email + password. Returns a bearer token that scopes subsequent calls to that user's session.</Aside> in the margin.
+
+## Type as apparatus
+
+The visual language borrows from editorial print: <Aside anchor="serif for titles, monospace for the apparatus" kind="value" title="The type stack" meta={["Inknut Antiqua", "Merriweather", "Roboto Mono"]}>Inknut Antiqua for titles, Merriweather as a fallback serif, Roboto Mono for body and marginalia. The mono signals *apparatus* rather than *prose*.</Aside>, generous line height, and a faint dashed underline that only hardens to a solid line when the reader shows interest.
+
+None of this is new. The novelty is only that it still feels novel, which tells you how thoroughly the web has been flattened into a single-column Medium article. There's another reading experience available, and it fits on the right.
+
+</Marginalia>

--- a/src/components/Marginalia/Aside.jsx
+++ b/src/components/Marginalia/Aside.jsx
@@ -1,0 +1,113 @@
+import React, { useCallback, useEffect, useId, useRef } from 'react';
+import clsx from 'clsx';
+import { useMarginalia } from './MarginaliaContext';
+import styles from './styles.module.scss';
+
+const KIND_LABELS = {
+  note: 'Note',
+  concept: 'Concept',
+  warning: 'Heads up',
+  info: 'Aside',
+  link: 'Related',
+  value: 'Value',
+  code: 'Code',
+  endpoint: 'Endpoint',
+};
+
+export default function Aside({
+  anchor,
+  title,
+  kind = 'note',
+  kindLabel,
+  meta,
+  cta,
+  ctaHref,
+  children,
+}) {
+  const id = useId();
+  const ctx = useMarginalia();
+  const anchorElRef = useRef(null);
+
+  const inlineLabel = anchor ?? children;
+  const body = anchor ? children : null;
+  const resolvedKindLabel = kindLabel ?? KIND_LABELS[kind] ?? 'Note';
+
+  const register = ctx?.register;
+  const unregister = ctx?.unregister;
+  const setAnchorRef = ctx?.setAnchorRef;
+
+  useEffect(() => {
+    if (!register) return;
+    register(id, {
+      kind,
+      kindLabel: resolvedKindLabel,
+      title,
+      body,
+      meta,
+      cta,
+      ctaHref,
+    });
+    return () => unregister?.(id);
+  }, [register, unregister, id, kind, resolvedKindLabel, title, body, meta, cta, ctaHref]);
+
+  const refCallback = useCallback(
+    (el) => {
+      anchorElRef.current = el;
+      setAnchorRef?.(id, el);
+    },
+    [setAnchorRef, id]
+  );
+
+  if (!ctx) {
+    return (
+      <span className={styles.anchor} title={title}>
+        {inlineLabel}
+      </span>
+    );
+  }
+
+  const hot = ctx.hotId === id;
+  const { setHotId, scrollCardIntoView } = ctx;
+
+  const activate = () => {
+    scrollCardIntoView(id);
+    if (anchorElRef.current) {
+      anchorElRef.current.animate(
+        [
+          { backgroundColor: 'var(--ifm-color-primary)', color: '#fff' },
+          { backgroundColor: 'transparent', color: 'inherit' },
+        ],
+        { duration: 600, easing: 'cubic-bezier(.2,.7,.2,1)' }
+      );
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      activate();
+    }
+  };
+
+  return (
+    <span
+      ref={refCallback}
+      className={clsx(styles.anchor, hot && styles.hot)}
+      title={title}
+      role="button"
+      tabIndex={0}
+      aria-pressed={hot}
+      onMouseEnter={() => setHotId(id)}
+      onMouseLeave={() => setHotId(null)}
+      onFocus={() => setHotId(id)}
+      onBlur={() => setHotId(null)}
+      onClick={(e) => {
+        e.preventDefault();
+        activate();
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      {inlineLabel}
+    </span>
+  );
+}

--- a/src/components/Marginalia/Endpoint.jsx
+++ b/src/components/Marginalia/Endpoint.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from './styles.module.scss';
+
+export default function Endpoint({ method = 'GET', path, children }) {
+  const upper = method.toUpperCase();
+  return (
+    <span className={styles.endpoint} data-method={upper}>
+      <span className={styles.endpointMethod}>{upper}</span>
+      <span className={styles.endpointPath}>{path ?? children}</span>
+    </span>
+  );
+}

--- a/src/components/Marginalia/Marginalia.jsx
+++ b/src/components/Marginalia/Marginalia.jsx
@@ -1,0 +1,303 @@
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
+import { MarginaliaContext } from './MarginaliaContext';
+import styles from './styles.module.scss';
+
+const GAP = 10;
+const READING_LINE = 0.32;
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+export default function Marginalia({ children, showProgress = true }) {
+  const [asides, setAsides] = useState([]);
+  const [hotId, setHotId] = useState(null);
+  const [nowReading, setNowReading] = useState('');
+  const [progress, setProgress] = useState(0);
+  const [lineGeom, setLineGeom] = useState(null);
+
+  const wrapRef = useRef(null);
+  const mainRef = useRef(null);
+  const marginRef = useRef(null);
+  const cardRefs = useRef(new Map());
+  const anchorRefs = useRef(new Map());
+  const asidesRef = useRef(asides);
+  asidesRef.current = asides;
+
+  const register = useCallback((id, data) => {
+    setAsides((prev) => {
+      const idx = prev.findIndex((a) => a.id === id);
+      if (idx >= 0) {
+        const next = prev.slice();
+        next[idx] = { id, ...data };
+        return next;
+      }
+      return [...prev, { id, ...data }];
+    });
+  }, []);
+
+  const unregister = useCallback((id) => {
+    setAsides((prev) => prev.filter((a) => a.id !== id));
+    cardRefs.current.delete(id);
+    anchorRefs.current.delete(id);
+  }, []);
+
+  const setAnchorRef = useCallback((id, el) => {
+    if (el) anchorRefs.current.set(id, el);
+    else anchorRefs.current.delete(id);
+  }, []);
+
+  const setCardRef = useCallback((id, el) => {
+    if (el) cardRefs.current.set(id, el);
+    else cardRefs.current.delete(id);
+  }, []);
+
+  const scrollCardIntoView = useCallback((id) => {
+    const cardEl = cardRefs.current.get(id);
+    if (!cardEl) return;
+    cardEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    cardEl.animate([{ transform: 'translateX(-10px)' }, { transform: 'translateX(-4px)' }], {
+      duration: 300,
+      easing: 'cubic-bezier(.2,.7,.2,1)',
+    });
+  }, []);
+
+  const positionCards = useCallback(() => {
+    const margin = marginRef.current;
+    if (!margin) return;
+    const marginRect = margin.getBoundingClientRect();
+    if (marginRect.width < 100) return;
+
+    const items = asidesRef.current
+      .map((a) => {
+        const anchorEl = anchorRefs.current.get(a.id);
+        const cardEl = cardRefs.current.get(a.id);
+        if (!anchorEl || !cardEl) return null;
+        const r = anchorEl.getBoundingClientRect();
+        return {
+          id: a.id,
+          cardEl,
+          naturalTop: r.top - marginRect.top + r.height / 2,
+          height: cardEl.offsetHeight,
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.naturalTop - b.naturalTop);
+
+    let cursor = 0;
+    items.forEach((it) => {
+      const desired = Math.max(it.naturalTop - it.height / 2, cursor);
+      it.cardEl.style.top = `${desired}px`;
+      it.cardEl.style.visibility = 'visible';
+      cursor = desired + it.height + GAP;
+    });
+  }, []);
+
+  const computeLine = useCallback((id) => {
+    if (!id) {
+      setLineGeom(null);
+      return;
+    }
+    const wrap = wrapRef.current;
+    const anchorEl = anchorRefs.current.get(id);
+    const cardEl = cardRefs.current.get(id);
+    if (!wrap || !anchorEl || !cardEl) {
+      setLineGeom(null);
+      return;
+    }
+    const wrapRect = wrap.getBoundingClientRect();
+    const aRect = anchorEl.getBoundingClientRect();
+    const cRect = cardEl.getBoundingClientRect();
+    const x1 = aRect.right - wrapRect.left;
+    const y1 = aRect.top + aRect.height / 2 - wrapRect.top;
+    const x2 = cRect.left - wrapRect.left;
+    const y2 = cRect.top + cRect.height / 2 - wrapRect.top;
+    if (x2 <= x1) {
+      setLineGeom(null);
+      return;
+    }
+    setLineGeom({ x1, y1, x2, y2 });
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    positionCards();
+  }, [asides, positionCards]);
+
+  useEffect(() => {
+    let raf = 0;
+    const schedule = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        positionCards();
+        computeLine(hotId);
+      });
+    };
+    window.addEventListener('resize', schedule);
+    const t1 = setTimeout(schedule, 300);
+    const t2 = setTimeout(schedule, 1200);
+
+    let ro;
+    if (typeof ResizeObserver !== 'undefined' && mainRef.current) {
+      ro = new ResizeObserver(schedule);
+      ro.observe(mainRef.current);
+    }
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', schedule);
+      clearTimeout(t1);
+      clearTimeout(t2);
+      ro?.disconnect();
+    };
+  }, [positionCards, computeLine, hotId]);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const readerY = window.innerHeight * READING_LINE;
+
+      if (mainRef.current) {
+        const mRect = mainRef.current.getBoundingClientRect();
+        const total = mRect.height - window.innerHeight;
+        const scrolled = -mRect.top;
+        const pct =
+          total > 0 ? Math.min(100, Math.max(0, (scrolled / total) * 100)) : scrolled > 0 ? 100 : 0;
+        setProgress(pct);
+
+        const headings = mainRef.current.querySelectorAll('h1, h2, h3, h4, h5, h6');
+        let activeText = '';
+        headings.forEach((h) => {
+          if (h.getBoundingClientRect().top - readerY < 0) {
+            activeText = h.textContent || '';
+          }
+        });
+        setNowReading((prev) => (prev === activeText ? prev : activeText));
+      }
+
+      let best = null;
+      let bestDist = Infinity;
+      asidesRef.current.forEach((a) => {
+        const el = anchorRefs.current.get(a.id);
+        if (!el) return;
+        const r = el.getBoundingClientRect();
+        const mid = r.top + r.height / 2;
+        const inView = r.bottom > 0 && r.top < window.innerHeight;
+        const dist = Math.abs(mid - readerY);
+        if (inView && dist < bestDist) {
+          best = a.id;
+          bestDist = dist;
+        }
+      });
+      setHotId((prev) => {
+        if (prev === best) return prev;
+        return best;
+      });
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  useEffect(() => {
+    computeLine(hotId);
+  }, [hotId, computeLine]);
+
+  const stableApi = useMemo(
+    () => ({ register, unregister, setAnchorRef, setHotId, scrollCardIntoView }),
+    [register, unregister, setAnchorRef, scrollCardIntoView]
+  );
+
+  const ctx = useMemo(() => ({ ...stableApi, hotId }), [stableApi, hotId]);
+
+  return (
+    <MarginaliaContext.Provider value={ctx}>
+      <div ref={wrapRef} className={styles.wrap}>
+        <div ref={mainRef} className={styles.main}>
+          {children}
+        </div>
+        <aside ref={marginRef} className={styles.margin} aria-label="Marginalia">
+          {showProgress && (
+            <div className={styles.stickyTop}>
+              <h5 className={styles.stickyLabel}>Now reading</h5>
+              <div className={styles.now}>{nowReading || '—'}</div>
+              <div className={styles.progress}>
+                <span style={{ width: `${progress}%` }} />
+              </div>
+            </div>
+          )}
+          {asides.map((a) => (
+            <Card
+              key={a.id}
+              aside={a}
+              hot={hotId === a.id}
+              setHotId={setHotId}
+              setCardRef={setCardRef}
+              anchorRefs={anchorRefs}
+            />
+          ))}
+        </aside>
+        {lineGeom && (
+          <svg className={styles.lineLayer} aria-hidden="true" style={{ pointerEvents: 'none' }}>
+            <line
+              x1={lineGeom.x1}
+              y1={lineGeom.y1}
+              x2={lineGeom.x2}
+              y2={lineGeom.y2}
+              className={styles.line}
+            />
+          </svg>
+        )}
+      </div>
+    </MarginaliaContext.Provider>
+  );
+}
+
+function Card({ aside, hot, setHotId, setCardRef, anchorRefs }) {
+  const refCallback = useCallback((el) => setCardRef(aside.id, el), [setCardRef, aside.id]);
+  return (
+    <div
+      ref={refCallback}
+      data-kind={aside.kind || 'note'}
+      className={clsx(styles.card, hot && styles.hot)}
+      style={{ visibility: 'hidden' }}
+      onMouseEnter={() => setHotId(aside.id)}
+      onMouseLeave={() => setHotId(null)}
+      onClick={() => {
+        const el = anchorRefs.current.get(aside.id);
+        if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }}
+    >
+      <CardInner aside={aside} />
+    </div>
+  );
+}
+
+export function CardInner({ aside }) {
+  return (
+    <>
+      {aside.kindLabel && (
+        <div className={styles.kind}>
+          <span className={styles.kindSwatch} />
+          {aside.kindLabel}
+        </div>
+      )}
+      {aside.title && <div className={styles.title}>{aside.title}</div>}
+      {aside.body && <div className={styles.body}>{aside.body}</div>}
+      {aside.meta && aside.meta.length > 0 && (
+        <div className={styles.metaRow}>
+          {aside.meta.map((m, i) => (
+            <span key={i} className={styles.pill}>
+              {m}
+            </span>
+          ))}
+        </div>
+      )}
+      {aside.cta &&
+        (aside.ctaHref ? (
+          <a href={aside.ctaHref} className={styles.cta} onClick={(e) => e.stopPropagation()}>
+            {aside.cta}
+          </a>
+        ) : (
+          <span className={styles.cta}>{aside.cta}</span>
+        ))}
+    </>
+  );
+}

--- a/src/components/Marginalia/MarginaliaContext.js
+++ b/src/components/Marginalia/MarginaliaContext.js
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export const MarginaliaContext = createContext(null);
+
+export function useMarginalia() {
+  return useContext(MarginaliaContext);
+}

--- a/src/components/Marginalia/index.js
+++ b/src/components/Marginalia/index.js
@@ -1,0 +1,3 @@
+export { default as Marginalia } from './Marginalia';
+export { default as Aside } from './Aside';
+export { default as Endpoint } from './Endpoint';

--- a/src/components/Marginalia/styles.module.scss
+++ b/src/components/Marginalia/styles.module.scss
@@ -1,0 +1,405 @@
+/* ============================================================
+   Marginalia — ref-anchored cards in the right margin
+============================================================ */
+
+.wrap {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 48px;
+  align-items: start;
+  margin: 2rem 0;
+}
+
+.main {
+  min-width: 0;
+}
+
+.margin {
+  position: relative;
+  min-height: 100%;
+  padding-top: 8px;
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+  color: var(--color-font-primary);
+}
+
+/* ---- Sticky "now reading" pill ---- */
+
+.stickyTop {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height, 60px) + 16px);
+  background: var(--color-background-primary);
+  padding: 0 0 12px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--color-offwhite-dark);
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stickyLabel {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-font-highlight);
+  margin: 0;
+  font-weight: 600;
+}
+
+.now {
+  font-family: var(--font-serif);
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--color-font-header);
+  line-height: 1.3;
+}
+
+.progress {
+  height: 2px;
+  background: var(--color-offwhite-dark);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress > span {
+  display: block;
+  height: 100%;
+  background: var(--color-green);
+  width: 0;
+  transition: width 0.2s ease-out;
+}
+
+[data-theme='dark'] .stickyTop {
+  background: var(--color-green);
+  border-bottom-color: var(--color-green-lighter);
+}
+
+[data-theme='dark'] .progress {
+  background: var(--color-green-lighter);
+}
+
+[data-theme='dark'] .progress > span {
+  background: var(--color-offwhite);
+}
+
+/* ---- Inline anchor ---- */
+
+.anchor {
+  cursor: pointer;
+  border-bottom: 1px dashed color-mix(in oklab, var(--color-green) 45%, transparent);
+  background: transparent;
+  padding: 0 1px;
+  scroll-margin-top: calc(var(--ifm-navbar-height, 60px) + 24px);
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.anchor:focus-visible {
+  outline: 2px solid var(--color-green);
+  outline-offset: 2px;
+  border-bottom-color: transparent;
+}
+
+[data-theme='dark'] .anchor:focus-visible {
+  outline-color: var(--color-offwhite);
+}
+
+.anchor:hover,
+.anchor.hot {
+  background: color-mix(in oklab, var(--color-green) 8%, transparent);
+  border-bottom-color: var(--color-green);
+}
+
+[data-theme='dark'] .anchor {
+  border-bottom-color: color-mix(in oklab, var(--color-offwhite) 45%, transparent);
+}
+
+[data-theme='dark'] .anchor:hover,
+[data-theme='dark'] .anchor.hot {
+  background: color-mix(in oklab, var(--color-offwhite) 12%, transparent);
+  border-bottom-color: var(--color-offwhite);
+}
+
+/* ---- Margin card ---- */
+
+.card {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: var(--color-offwhite-light);
+  border: 1px solid var(--color-offwhite-dark);
+  border-radius: 8px;
+  padding: 12px 14px;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: var(--color-font-primary);
+  opacity: 0.68;
+  transform: translateX(0);
+  cursor: pointer;
+  scroll-margin-top: calc(var(--ifm-navbar-height, 60px) + 100px);
+  transition:
+    transform 0.35s cubic-bezier(0.2, 0.7, 0.2, 1),
+    opacity 0.25s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+  will-change: transform, opacity, top;
+}
+
+.card.hot {
+  opacity: 1;
+  border-color: var(--color-green);
+  box-shadow:
+    0 6px 18px rgba(47, 84, 73, 0.12),
+    0 0 0 1px var(--color-green);
+  transform: translateX(-4px);
+}
+
+[data-theme='dark'] .card {
+  background: var(--color-green-light);
+  border-color: var(--color-green-lighter);
+  color: var(--color-offwhite);
+}
+
+[data-theme='dark'] .card.hot {
+  border-color: var(--color-offwhite);
+  box-shadow:
+    0 6px 18px rgba(0, 0, 0, 0.25),
+    0 0 0 1px var(--color-offwhite);
+}
+
+.kind {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-font-highlight);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.kindSwatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--color-green);
+  flex-shrink: 0;
+}
+
+.card[data-kind='warning'] .kindSwatch {
+  background: var(--color-red);
+}
+.card[data-kind='concept'] .kindSwatch {
+  background: var(--color-green);
+}
+.card[data-kind='value'] .kindSwatch {
+  background: var(--color-font-highlight);
+}
+.card[data-kind='link'] .kindSwatch {
+  background: var(--color-green-lighter);
+}
+.card[data-kind='code'] .kindSwatch {
+  background: var(--color-green-dark);
+}
+.card[data-kind='note'] .kindSwatch {
+  background: var(--color-offwhite-alt-dark);
+}
+.card[data-kind='endpoint'] .kindSwatch {
+  background: var(--color-red);
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-weight: 500;
+  font-size: 0.92rem;
+  line-height: 1.3;
+  color: var(--color-font-header);
+  margin-bottom: 4px;
+}
+
+[data-theme='dark'] .title {
+  color: var(--color-offwhite);
+}
+
+.body {
+  margin: 0;
+  color: var(--color-font-primary);
+}
+
+[data-theme='dark'] .body {
+  color: var(--color-offwhite);
+}
+
+.body > :first-child {
+  margin-top: 0;
+}
+
+.body > :last-child {
+  margin-bottom: 0;
+}
+
+.body p {
+  margin: 0 0 0.5em;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+}
+
+.body code {
+  font-size: 0.92em;
+}
+
+.metaRow {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--color-green) 8%, transparent);
+  border: 1px solid var(--color-offwhite-dark);
+  color: var(--color-font-highlight);
+}
+
+[data-theme='dark'] .pill {
+  background: var(--color-green-dark);
+  border-color: var(--color-green-lighter);
+  color: var(--color-offwhite);
+}
+
+.cta {
+  display: inline-block;
+  margin-top: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-green);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.cta:hover {
+  border-bottom-color: var(--color-green);
+}
+
+[data-theme='dark'] .cta {
+  color: var(--color-offwhite);
+}
+
+[data-theme='dark'] .cta:hover {
+  border-bottom-color: var(--color-offwhite);
+}
+
+/* ---- Connecting line ---- */
+
+.lineLayer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.line {
+  stroke: var(--color-green);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+  opacity: 0.6;
+  animation: lineFade 0.2s ease-out;
+}
+
+[data-theme='dark'] .line {
+  stroke: var(--color-offwhite);
+}
+
+@keyframes lineFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.6;
+  }
+}
+
+/* ---- Endpoint inline chip ---- */
+
+.endpoint {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  padding: 2px 8px;
+  background: var(--color-offwhite-light);
+  border: 1px solid var(--color-offwhite-dark);
+  border-radius: 5px;
+  color: var(--color-font-primary);
+  vertical-align: baseline;
+  white-space: nowrap;
+  line-height: 1.5;
+}
+
+.endpointMethod {
+  font-weight: 700;
+  font-size: 0.85em;
+  padding: 0 5px;
+  border-radius: 3px;
+  letter-spacing: 0.06em;
+}
+
+.endpoint[data-method='GET'] .endpointMethod {
+  color: #1e8a5a;
+  background: #e2f3ea;
+}
+
+.endpoint[data-method='POST'] .endpointMethod {
+  color: #c97b1f;
+  background: #faf0dd;
+}
+
+.endpoint[data-method='PUT'] .endpointMethod,
+.endpoint[data-method='PATCH'] .endpointMethod {
+  color: var(--color-green-dark);
+  background: color-mix(in oklab, var(--color-green) 12%, transparent);
+}
+
+.endpoint[data-method='DELETE'] .endpointMethod {
+  color: #c0423e;
+  background: #fbe7e6;
+}
+
+[data-theme='dark'] .endpoint {
+  background: var(--color-green-light);
+  border-color: var(--color-green-lighter);
+  color: var(--color-offwhite);
+}
+
+.endpointPath {
+  color: inherit;
+}
+
+/* ---- Responsive collapse ---- */
+
+@media (max-width: 1200px) {
+  .wrap {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0;
+  }
+  .margin {
+    display: none;
+  }
+  .lineLayer {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `<Marginalia>` / `<Aside>` / `<Endpoint>` component trio under `src/components/Marginalia/` that enables Tufte-style editorial sidenotes in blog posts. Ported from the Claude Design Weavr quickstart brief.

## What it does

- `<Aside>` renders an inline anchor (dashed underline) in prose and registers a corresponding card in the right margin.
- `<Marginalia>` packs the cards top-down without overlap, tracks the reader's scroll position, and lights up the card nearest the "reading line" (~32% down the viewport).
- Hover on either side syncs the highlight to the other; click an anchor to scroll its card into view with a small pulse.
- Sticky "Now reading" progress pill with heading tracker + scroll progress bar.
- SVG connecting line from the hot anchor to its card.
- `<Endpoint>` inline chip for API-doc flavored posts (method-colored GET/POST/PUT/DELETE).
- Keyboard accessible: `role=button`, `tabindex=0`, `aria-pressed`, Enter/Space activation, `:focus-visible` outline.
- Themed to the site's existing green / offwhite / Inknut Antiqua palette.
- Collapses gracefully on viewports below 1200px (margin hidden, anchor keeps native `title` tooltip).

## Usage

```mdx
import { Marginalia, Aside, Endpoint } from '@site/src/components/Marginalia';

<Marginalia>
  The concept of <Aside anchor="pattern languages" kind="concept" title="Christopher Alexander" meta={["1977", "253 patterns"]}>*A Pattern Language* (1977) catalogued 253 design patterns for towns and buildings.</Aside> has shaped software architecture thinking.
</Marginalia>
```

Kinds: `note | concept | warning | info | link | value | code | endpoint`. Optional props: `meta` (array of pill strings), `cta` + `ctaHref`.

## Test plan

- [x] Production build passes (`npm run build`)
- [x] Browser-verified via Playwright at 1440px: hover on anchor lights anchor + card + SVG line; hover on card does the reverse; scroll-driven hot card follows the reading line; "Now reading" tracks active heading; progress bar updates
- [x] Keyboard: Tab focuses anchor, Enter activates (scrolls card), Blur clears hot state
- [x] CTA with no `ctaHref` renders as `<span>`, not dead `<a href="#">`
- [x] Progress math safe when main content is shorter than viewport
- [x] Responsive: margin collapses to `display: none` below 1200px
- [x] Prettier-formatted

A draft demo post (`blog/2026-04-18-marginalia-demo.mdx`) exercises every prop. Flip `draft: false` to publish.

## Notes

On mobile the margin column is hidden; readers see the dashed anchor but not the card body. Native `title` tooltips work on desktop. A future enhancement could add a tap-to-expand popover for touch devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)