### PR TITLE
Strip MDX imports from latest post preview

### DIFF
--- a/src/plugins/latest-blog-plugin.js
+++ b/src/plugins/latest-blog-plugin.js
@@ -47,7 +47,11 @@ module.exports = function latestBlogPlugin(context) {
         const excerpt = truncatePattern.test(fm.body)
           ? fm.body.split(truncatePattern)[0].trim()
           : fm.body;
-        const excerptHtml = marked.parse(excerpt);
+        // Strip MDX import/export statements so they don't render as text
+        const cleaned = excerpt
+          .replace(/^\s*(?:import|export)\s+[^\n]*\n?/gm, '')
+          .trim();
+        const excerptHtml = marked.parse(cleaned);
 
         return {
           title: fm.title || textSlug,


### PR DESCRIPTION
The homepage LatestPost component was rendering raw MDX import
statements as text in the excerpt. Strip import/export lines from
the excerpt before passing to marked.