### PR TITLE
Fix broken napowrimo link in Playground rhyme post

### DIFF
--- a/blog/2026-04-07-playground-rhyme.md
+++ b/blog/2026-04-07-playground-rhyme.md
@@ -33,4 +33,4 @@ in regret.
 
 ---
 
-[Day seven](https://www.napowrimo.net/day-seven-13/).
+[Day seven](https://www.napowrimo.net/day-seven-12/).


### PR DESCRIPTION
## Summary
- The link check (issue #608) flagged `https://www.napowrimo.net/day-seven-13/` as a 404 in `blog/2026-04-07-playground-rhyme.md`.
- The correct URL for the 2026 Day 7 NaPoWriMo prompt (jump-rope rhymes — which this post riffs on) is `https://www.napowrimo.net/day-seven-12/`.

## Test plan
- [x] Verified the corrected URL resolves and serves the matching jump-rope-rhymes prompt.
- [ ] Next scheduled linknator run should pass once merged.

Fixes #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)