### PR TITLE
Apply prettier to plugin files

### DIFF
--- a/src/plugins/latest-blog-plugin.js
+++ b/src/plugins/latest-blog-plugin.js
@@ -48,9 +48,7 @@ module.exports = function latestBlogPlugin(context) {
           ? fm.body.split(truncatePattern)[0].trim()
           : fm.body;
         // Strip MDX import/export statements so they don't render as text
-        const cleaned = excerpt
-          .replace(/^\s*(?:import|export)\s+[^\n]*\n?/gm, '')
-          .trim();
+        const cleaned = excerpt.replace(/^\s*(?:import|export)\s+[^\n]*\n?/gm, '').trim();
         const excerptHtml = marked.parse(cleaned);
 
         return {

--- a/src/plugins/marginalia-plugin/README.md
+++ b/src/plugins/marginalia-plugin/README.md
@@ -7,9 +7,7 @@ Editorial sidenotes for Docusaurus blog posts and docs. Inline anchors in prose 
 This plugin lives in-tree. Register it in `docusaurus.config.js`:
 
 ```js
-plugins: [
-  [require.resolve('./src/plugins/marginalia-plugin'), {}],
-];
+plugins: [[require.resolve('./src/plugins/marginalia-plugin'), {}]];
 ```
 
 Requires `docusaurus-plugin-sass` (the components use SCSS modules).
@@ -21,7 +19,7 @@ import { Marginalia, Aside, Endpoint } from '@theme/Marginalia';
 
 <Marginalia>
 
-The concept of <Aside anchor="pattern languages" kind="concept" title="Christopher Alexander" meta={["1977", "253 patterns"]}>*A Pattern Language* catalogued 253 design patterns for towns and buildings.</Aside> has shaped software thinking.
+The concept of <Aside anchor="pattern languages" kind="concept" title="Christopher Alexander" meta={["1977", "253 patterns"]}>_A Pattern Language_ catalogued 253 design patterns for towns and buildings.</Aside> has shaped software thinking.
 
 </Marginalia>
 ```
@@ -32,24 +30,24 @@ The concept of <Aside anchor="pattern languages" kind="concept" title="Christoph
 
 Container establishing the two-column reading layout. Props:
 
-| Prop | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `showProgress` | `boolean` | `true` | Sticky "Now reading" pill + scroll progress bar |
+| Prop           | Type      | Default | Notes                                           |
+| -------------- | --------- | ------- | ----------------------------------------------- |
+| `showProgress` | `boolean` | `true`  | Sticky "Now reading" pill + scroll progress bar |
 
 ### `<Aside>`
 
 Inline anchor paired with a margin card. Props:
 
-| Prop | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `anchor` | `ReactNode` | `children` | Inline text in prose (if omitted, children is used) |
-| `title` | `string` | — | Card heading |
-| `kind` | `'note' \| 'concept' \| 'warning' \| 'info' \| 'link' \| 'value' \| 'code' \| 'endpoint'` | `'note'` | Color swatch |
-| `kindLabel` | `string` | Derived from `kind` | Override the uppercase label |
-| `meta` | `string[]` | — | Pill tags shown below body |
-| `cta` | `string` | — | Call-to-action text at bottom |
-| `ctaHref` | `string` | — | CTA href. If omitted, renders as `<span>` |
-| `children` | `ReactNode` | — | Card body (when `anchor` is set) or inline anchor (when not) |
+| Prop        | Type                                                                                      | Default             | Notes                                                        |
+| ----------- | ----------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------ |
+| `anchor`    | `ReactNode`                                                                               | `children`          | Inline text in prose (if omitted, children is used)          |
+| `title`     | `string`                                                                                  | —                   | Card heading                                                 |
+| `kind`      | `'note' \| 'concept' \| 'warning' \| 'info' \| 'link' \| 'value' \| 'code' \| 'endpoint'` | `'note'`            | Color swatch                                                 |
+| `kindLabel` | `string`                                                                                  | Derived from `kind` | Override the uppercase label                                 |
+| `meta`      | `string[]`                                                                                | —                   | Pill tags shown below body                                   |
+| `cta`       | `string`                                                                                  | —                   | Call-to-action text at bottom                                |
+| `ctaHref`   | `string`                                                                                  | —                   | CTA href. If omitted, renders as `<span>`                    |
+| `children`  | `ReactNode`                                                                               | —                   | Card body (when `anchor` is set) or inline anchor (when not) |
 
 ### `<Endpoint>`
 

--- a/src/plugins/marginalia-plugin/src/theme/Marginalia/Marginalia.jsx
+++ b/src/plugins/marginalia-plugin/src/theme/Marginalia/Marginalia.jsx
@@ -204,9 +204,7 @@ export default function Marginalia({ children, showToc = true }) {
   useEffect(() => {
     if (!mainRef.current) return;
     const collect = () => {
-      const els = mainRef.current.querySelectorAll(
-        'h1[id], h2[id]'
-      );
+      const els = mainRef.current.querySelectorAll('h1[id], h2[id]');
       const list = Array.from(els).map((el) => ({
         id: el.id,
         text: el.textContent || '',
@@ -244,9 +242,7 @@ export default function Marginalia({ children, showToc = true }) {
           total > 0 ? Math.min(100, Math.max(0, (scrolled / total) * 100)) : scrolled > 0 ? 100 : 0;
         setProgress(pct);
 
-        const headingEls = mainRef.current.querySelectorAll(
-          'h1[id], h2[id]'
-        );
+        const headingEls = mainRef.current.querySelectorAll('h1[id], h2[id]');
         let activeId = null;
         headingEls.forEach((h) => {
           if (h.getBoundingClientRect().top - readerY < 0) {


### PR DESCRIPTION
## Summary
- Running `npm run format:fix` produced changes in three files that had drifted from prettier style after recent plugin work (#609, #610, #611).
- No behavior changes — purely formatting.

## Test plan
- [x] `npm run format` reports "All matched files use Prettier code style!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)