### PR TITLE
Fix security findings: CI script injection, subscribe API, env generation

### DIFF
--- a/.github/workflows/add-words.yml
+++ b/.github/workflows/add-words.yml
@@ -6,9 +6,11 @@ on:
 
 jobs:
   add-words:
+    # Only trusted users may trigger this — it has write access and runs on PR input.
     if: >
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/add-words')
+      contains(github.event.comment.body, '/add-words') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -63,17 +65,20 @@ jobs:
             console.log(`Found words: ${words.join(', ')}`);
 
       - name: Add words to cspell.json
+        # WORDS is passed via env (never interpolated into the script body) to
+        # prevent shell/JS injection from untrusted comment content.
+        env:
+          WORDS: ${{ steps.words.outputs.words }}
         run: |
-          WORDS='${{ steps.words.outputs.words }}'
-          node -e "
-            const fs = require('fs');
-            const config = JSON.parse(fs.readFileSync('cspell.json', 'utf8'));
-            const newWords = JSON.parse(process.argv[1]);
-            const merged = [...new Set([...config.words, ...newWords])].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+          node -e '
+            const fs = require("fs");
+            const config = JSON.parse(fs.readFileSync("cspell.json", "utf8"));
+            const newWords = JSON.parse(process.env.WORDS);
+            const merged = [...new Set([...config.words, ...newWords])].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
             config.words = merged;
-            fs.writeFileSync('cspell.json', JSON.stringify(config, null, 2) + '\n');
-            console.log('Updated cspell.json with words:', newWords.join(', '));
-          " "$WORDS"
+            fs.writeFileSync("cspell.json", JSON.stringify(config, null, 2) + "\n");
+            console.log("Updated cspell.json with words:", newWords.join(", "));
+          '
 
       - name: Commit and push
         run: |
@@ -87,6 +92,8 @@ jobs:
 
       - name: React to comment
         uses: actions/github-script@v7
+        env:
+          WORDS: ${{ steps.words.outputs.words }}
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -96,7 +103,7 @@ jobs:
               content: '+1',
             });
 
-            const words = JSON.parse('${{ steps.words.outputs.words }}');
+            const words = JSON.parse(process.env.WORDS);
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -1,12 +1,43 @@
 // Vercel serverless function — adds email to Resend audience
+
+// Practical email check: a single @, non-empty local part, a dotted domain.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LENGTH = 254;
+
+// Lightweight in-memory rate limiter. Per warm instance only (Vercel may run
+// several), so it is a speed bump against abuse rather than a hard guarantee.
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 5;
+const requestLog = new Map(); // ip -> number[] (timestamps)
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  const recent = (requestLog.get(ip) || []).filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+  recent.push(now);
+  requestLog.set(ip, recent);
+  return recent.length > RATE_LIMIT_MAX;
+}
+
+function getClientIp(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress || 'unknown';
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { email } = req.body;
+  if (isRateLimited(getClientIp(req))) {
+    return res.status(429).json({ error: 'Too many requests' });
+  }
 
-  if (!email || !email.includes('@')) {
+  const email = req.body && typeof req.body === 'object' ? req.body.email : undefined;
+
+  if (typeof email !== 'string' || email.length > MAX_EMAIL_LENGTH || !EMAIL_RE.test(email)) {
     return res.status(400).json({ error: 'Valid email required' });
   }
 

--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -19,6 +19,10 @@ if (fs.existsSync(envPath)) {
   process.exit(0);
 }
 
+// Only these keys are safe to expose in the public client bundle.
+// Never add server-only secrets (e.g. RESEND_API_KEY) here.
+const CLIENT_SAFE_KEYS = ['POSTHOG_KEY', 'POSTHOG_HOST', 'NODE_ENV'];
+
 // Parse environment variables
 const envVars = {};
 envContent.split('\n').forEach((line) => {
@@ -31,12 +35,17 @@ envContent.split('\n').forEach((line) => {
   }
 });
 
-// Generate env.js content
+// Drop anything not on the allowlist before it can reach the public bundle.
+const safeVars = Object.fromEntries(
+  Object.entries(envVars).filter(([key]) => CLIENT_SAFE_KEYS.includes(key))
+);
+
+// Generate env.js content (JSON.stringify keeps values safely escaped)
 const envJsContent = `// Environment variables for client-side use
 // This file is generated during build and contains safe environment variables
 window.__ENV__ = {
-${Object.entries(envVars)
-  .map(([key, value]) => `  ${key}: '${value}'`)
+${Object.entries(safeVars)
+  .map(([key, value]) => `  ${key}: ${JSON.stringify(value)}`)
   .join(',\n')}
 };
 `;

--- a/static/env.js
+++ b/static/env.js
@@ -1,5 +1,5 @@
 // Environment variables for client-side use
 // This file is generated during build and contains safe environment variables
 window.__ENV__ = {
-  POSTHOG_KEY: 'phc_cBJdytohyJRWGP4RlxpVX4aOMkRome3vwrxmfi81hy8'
+  POSTHOG_KEY: "phc_cBJdytohyJRWGP4RlxpVX4aOMkRome3vwrxmfi81hy8"
 };


### PR DESCRIPTION
## Summary

Focused security review of the genuine attack surface (API routes, secret handling, CI workflows). Static-site OWASP checks were skipped as not applicable.

### 🔴 HIGH — `add-words.yml` script injection (#620)
The workflow triggered on any `/add-words` issue comment from **any** user and interpolated untrusted comment-derived text directly into shell/JS while holding `contents: write`. `JSON.stringify` preserves literal quotes, allowing shell breakout → arbitrary command execution.
- Gated the trigger on `author_association` ∈ {OWNER, MEMBER, COLLABORATOR}.
- Step outputs now passed via `env:` vars instead of inline `${{ }}`.

### 🟡 MEDIUM — subscribe API hardening (#621)
- Added per-IP in-memory rate limiting (5/min).
- Replaced `email.includes('@')` with a real regex + length cap.
- Guarded against missing/non-object request bodies.

### 🟡 LOW-MEDIUM — env generation allowlist (#622)
`generate-env.js` copied every `.env` var into the publicly served `static/env.js`. Added an explicit `CLIENT_SAFE_KEYS` allowlist so server secrets can never leak; values are now `JSON.stringify`-escaped.

## Testing
- `npm test` — 16/16 pass
- `node scripts/generate-env.js` — regenerates `env.js` with allowlisted keys only

Fixes #620
Fixes #621
Fixes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)